### PR TITLE
Fix types path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.4",
   "description": "",
   "main": "dist/index.js",
-  "types": "types/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "npx tsc",
     "prepack": "npm run build",


### PR DESCRIPTION
The output defined in `tsconfig.json` is `./dist`
but in `package.json` the types is pointing to a non-existing `types/index.d.ts` path  